### PR TITLE
Update `font-size` declaration's type from number to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ const compileCSS = (root, images, ratio) => {
 			['height', `${size.height / ratio}px`],
 			['display', 'inline-block'],
 			['vertical-align', 'middle'],
-			['font-size', 0]
+			['font-size', '0px']
 		];
 
 		rule.source = root.source;


### PR DESCRIPTION
When used with sass, the Number declaration for `font-size` breaks in Autoprefixer's `old-value` method (https://github.com/postcss/autoprefixer/blob/master/lib/old-value.js#L15). 

This pull request makes sure that the provided value for `font-size` is a string.
